### PR TITLE
feat: add support for custom classes with camelCase or numbers

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -172,6 +172,9 @@ test('compose classes', () => {
     classes: {
       disabled: classNames('bgGray borderRed'),
       debug: apply(C.border1, C.borderRed),
+      letter0: { letterSpacing: 0 },
+      letter2: apply(C.borderRed, { letterSpacing: 2 }),
+      letterZero: { letterSpacing: 3 },
     },
   });
 
@@ -179,6 +182,12 @@ test('compose classes', () => {
     { backgroundColor: 'gray' },
     { borderColor: 'red' },
   ]);
+
+  expect(C.letter0).toEqual({ letterSpacing: 0 });
+
+  expect(C.letter2).toEqual([{ borderColor: 'red' }, { letterSpacing: 2 }]);
+
+  expect(C.letterZero).toEqual({ letterSpacing: 3 });
 
   expect(C.disabled).toEqual([
     { backgroundColor: 'gray' },

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -22,6 +22,8 @@ const fonts: StringObject = {};
 
 const classes: DynamicObject<StyleProp<Styles | {}>> = {};
 
+const classesDictionary: string[] = [];
+
 const fontWeights: StringObject = {
   '': 'normal',
   hairline: '100',
@@ -89,4 +91,5 @@ export default {
   shadows,
   sizing,
   classes,
+  classesDictionary,
 };


### PR DESCRIPTION
* Add support to use custom classes with the library convention `Ex: letter0 | letterZero`

NOTE: Should be good to type the extend in order to prevent to use custom classes with "reserved classes" from the dictionary. I have a POC but is not totally working at the moment. I will open a draft PR with my solution in order to discuss how to do it.