### PR TITLE
feat: avoid dictionary keys in classes

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -231,6 +231,11 @@ test('compose classes', () => {
       disabled: classNames(null, 'bgGray borderRed'),
       debug: apply(C.border1, C.borderRed),
       letter0: { letterSpacing: 0 },
+      letter2: apply(C.borderRed, { letterSpacing: 2 }),
+      letterZero: { letterSpacing: 3 },
+      // Should get an error
+      font: { fontSize: 20 },
+      font12: { fontSize: 20 },
     },
   });
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -271,6 +271,11 @@ test('compose classes', () => {
     { borderColor: 'primary' },
     { color: 'blue' },
   ]);
+  expect(C.letter0).toEqual({ letterSpacing: 0 });
+
+  expect(C.letter2).toEqual([{ borderColor: 'red' }, { letterSpacing: 2 }]);
+
+  expect(C.letterZero).toEqual({ letterSpacing: 3 });
 
   expect(C.disabled).toEqual([
     { backgroundColor: 'gray' },

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,5 +1,5 @@
 import { StyleProp, StyleSheet, Platform } from 'react-native';
-import { StringObject, DynamicObject, Styles } from './types';
+import { StringObject, DynamicObject, Styles, ClassesKey } from './types';
 
 const sizing: DynamicObject<number | string> = {
   base: 4,
@@ -33,7 +33,9 @@ const colors: StringObject = {};
 
 const fonts: StringObject = {};
 
-const classes: DynamicObject<StyleProp<Styles | {}>> = {};
+const classes: ClassesKey = {};
+
+const classesDictionary: string[] = [];
 
 const fontWeights: StringObject = {
   '': 'normal',
@@ -95,6 +97,8 @@ const shadows: DynamicObject<Styles> = {
 
 export default {
   alignment,
+  classes,
+  classesDictionary,
   colors,
   components,
   fonts,
@@ -102,5 +106,4 @@ export default {
   fontWeights,
   shadows,
   sizing,
-  classes,
 };

--- a/src/core.ts
+++ b/src/core.ts
@@ -77,7 +77,7 @@ const StylesCacheManager = {
   },
 };
 
-type CustomConfig = string | Omit<typeof constants, 'classesDictionary'>;
+type CustomConfig = Omit<typeof constants, 'classesDictionary'>;
 type ConstantsKey = keyof CustomConfig;
 
 export const extend = (custom: Partial<CustomConfig>) => {
@@ -91,6 +91,9 @@ export const extend = (custom: Partial<CustomConfig>) => {
       }
     });
   });
+
+  constants.classesDictionary =
+    Object.entries(constants.classes).map(([k]) => camelCaseSplit(k)[0]) || [];
 };
 
 export const exists = (key: string) => key in C;
@@ -105,9 +108,10 @@ const handler = {
 
     if (!isAValidKey(name)) return target;
     const [key, value] = camelCaseSplit(name);
+
     if (
       !dictionary.hasOwnProperty(key) &&
-      !constants.classes.hasOwnProperty(name)
+      !constants.classesDictionary.includes(key)
     ) {
       warnOnInvalidKey(`The key ${key} doesnt exists`);
       return target;

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,13 @@
-import { Dimensions, StyleProp } from 'react-native';
+import { Dimensions, StyleProp, ViewStyle } from 'react-native';
 import constants, { Breakpoint } from './constants';
-import dictionary, { DictionaryKeys } from './dictionary';
-import { DynamicObject, Styles, StylesObject } from './types';
+import dictionary from './dictionary';
+import {
+  DictionaryKeys,
+  DynamicObject,
+  NonDictionaryKeys,
+  Styles,
+  StylesObject,
+} from './types';
 import { camelCaseSplit, isEmpty, warnOnInvalidKey } from './utils';
 
 type StylesArray = Array<StyleProp<Styles> | string>;
@@ -60,8 +66,6 @@ export const responsive = (
   return apply(currentStyle);
 };
 
-type ConstantsKey = keyof typeof constants;
-
 const StylesCacheManager = {
   cache: {} as DynamicObject<Styles>,
   get: (key: string) => StylesCacheManager.cache[key],
@@ -73,7 +77,10 @@ const StylesCacheManager = {
   },
 };
 
-export const extend = (custom: Partial<typeof constants>) => {
+type CustomConfig = string | Omit<typeof constants, 'classesDictionary'>;
+type ConstantsKey = keyof CustomConfig;
+
+export const extend = (custom: Partial<CustomConfig>) => {
   // clear cache to override previous values with new config
   StylesCacheManager.clear();
   Object.keys(custom).forEach((type: string) => {
@@ -92,9 +99,10 @@ const isAValidKey = (key: string) =>
   typeof key === 'string' && !['$$typeof', 'prototype', 'toJSON'].includes(key);
 
 const handler = {
-  get: function(target: StylesObject, name: string): Styles {
+  get: function(target: StylesObject, name: string): StylesObject | ViewStyle {
     const valueInCache = StylesCacheManager.get(name);
     if (valueInCache) return valueInCache;
+
     if (!isAValidKey(name)) return target;
     const [key, value] = camelCaseSplit(name);
     if (
@@ -105,8 +113,9 @@ const handler = {
       return target;
     }
     const valueForKey =
-      constants.classes[name] ??
-      dictionary[key as DictionaryKeys]?.(value, key);
+      dictionary[key as DictionaryKeys]?.(value, key) ||
+      constants.classes[name.toLowerCase() as keyof NonDictionaryKeys];
+
     StylesCacheManager.set(name, valueForKey);
     return valueForKey;
   },

--- a/src/dictionary.ts
+++ b/src/dictionary.ts
@@ -150,6 +150,4 @@ const dictionary = {
   shadow: getBoxShadow,
 };
 
-export type DictionaryKeys = keyof typeof dictionary;
-
 export default dictionary;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,22 @@
+import { ViewStyle, ImageStyle, TextStyle, StyleProp } from 'react-native';
+import dictionary from './dictionary';
+
+type StringObject = DynamicObject<string>;
+
+type AnyObject = DynamicObject<any>;
+
+type Styles = ViewStyle | ImageStyle | TextStyle;
+
+type DictionaryKeys = keyof typeof dictionary;
+
+type NonDictionaryKeys = keyof Omit<'', DictionaryKeys>;
+
+type StylesObjectKeys = string | DictionaryKeys;
+
+type CustomClassKeys = NonDictionaryKeys;
+
+type ClassesKey = DynamicObject<StyleProp<Styles | {}>>;
+
+interface DynamicObject<T> {
+  [key: string]: T;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { ViewStyle, ImageStyle, TextStyle } from 'react-native';
-import { DictionaryKeys } from './dictionary';
+import { ViewStyle, ImageStyle, TextStyle, StyleProp } from 'react-native';
+import dictionary from './dictionary';
 
 export type DynamicObject<T, K extends string = string> = Record<string | K, T>;
 
@@ -8,3 +8,11 @@ export type StringObject = DynamicObject<string>;
 export type Styles = ViewStyle | ImageStyle | TextStyle;
 
 export type StylesObject = DynamicObject<Styles, DictionaryKeys>;
+
+export type DictionaryKeys = keyof typeof dictionary;
+
+export type NonDictionaryKeys = keyof Omit<'', DictionaryKeys>;
+
+export type StylesObjectKeys = string | DictionaryKeys;
+
+export type ClassesKey = DynamicObject<StyleProp<Styles | {}>>;


### PR DESCRIPTION
[Changes in this commit](https://github.com/mateosilguero/consistencss/commit/79b87499fa86ea907ff317c818b02384f1643b66)

* Prevent the user to overwrite a library dictionary class with custom classes.

Right now, typing changes apparently look good but I'm not getting the typescript error when I try to create a custom class using a reserved key.

I open this PR as a draft to discuss and maybe found a solution for this.