### PR TITLE
feat: add responsive method for different screen sizes

### DIFF
--- a/docs/responsive.md
+++ b/docs/responsive.md
@@ -1,0 +1,40 @@
+---
+id: responsive
+title: responsive
+---
+
+responsive API. apply styles depending of screen width.
+
+```js
+import { apply, classNames, extend, responsive } from 'consistencss';
+
+extend({
+  layout: {
+    sm: {
+      lte: 300,
+    },
+    md: {
+      gte: 301,
+      lte: 500,
+    },
+    l: {
+      gte: 501,
+    },
+  },
+});
+
+const App = ({ active }) => (
+  <View
+    style={responsive({
+      sm: apply(C.bgRed),
+      md: C.bgBlue,
+      l: classNames({
+        bgGreen: active,
+        bgBlack: !active 
+      })
+    })}
+  >
+    ...
+  </View>
+);
+```

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -247,14 +247,14 @@ PODS:
     - React-Core (= 0.63.2)
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
-  - RNCMaskedView (0.1.9):
+  - RNCMaskedView (0.1.10):
     - React
-  - RNGestureHandler (1.6.1):
+  - RNGestureHandler (1.8.0):
     - React
-  - RNReanimated (1.8.0):
+  - RNReanimated (1.13.1):
     - React
-  - RNScreens (2.5.0):
-    - React
+  - RNScreens (2.12.0):
+    - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -377,7 +377,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-safe-area-context: e200d4433aba6b7e60b52da5f37af11f7a0b0392
+  react-native-safe-area-context: 8260e5157617df4b72865f44006797f895b2ada7
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
@@ -388,12 +388,12 @@ SPEC CHECKSUMS:
   React-RCTText: 1b6773e776e4b33f90468c20fe3b16ca3e224bb8
   React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
-  RNCMaskedView: 71fc32d971f03b7f03d6ab6b86b730c4ee64f5b6
-  RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
-  RNReanimated: 955cf4068714003d2f1a6e2bae3fb1118f359aff
-  RNScreens: ac02d0e4529f08ced69f5580d416f968a6ec3a1d
+  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
+  RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
+  RNReanimated: dd8c286ab5dd4ba36d3a7fef8bff7e08711b5476
+  RNScreens: 4b488fdf9537bbce829e2910c8cce1d17f6d9be8
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
 
 PODFILE CHECKSUM: ee1e180c421b011e024f8e7c1f213cf921a968ff
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,6 +28,18 @@ extend({
     s: 14,
     m: 16,
   },
+  layout: {
+    sm: {
+      lte: 300,
+    },
+    md: {
+      gte: 301,
+      lte: 500,
+    },
+    lg: {
+      gte: 501,
+    },
+  },
 });
 
 const Stack = createStackNavigator();

--- a/example/src/views/Home.tsx
+++ b/example/src/views/Home.tsx
@@ -7,14 +7,27 @@
  */
 
 import React, { FC } from 'react';
-import { ScrollView, useWindowDimensions } from 'react-native';
-import C, { apply, Text, TouchableOpacity, View } from 'consistencss';
+import { Dimensions, ScrollView, useWindowDimensions } from 'react-native';
+import C, {
+  apply,
+  responsive,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'consistencss';
 import { NavigationStack } from '../types';
 
 const Home: FC<{
   navigation: NavigationStack;
 }> = ({ navigation }) => {
   useWindowDimensions();
+
+  const responsiveColor = responsive({
+    sm: C.textGreen,
+    md: C.textBlue,
+    lg: C.textRed,
+  });
+
   return (
     <ScrollView>
       <View style={apply(C.bgRed, C.h16, C.wscreen)}>
@@ -45,6 +58,21 @@ const Home: FC<{
         <Text style={apply(C.textBlue, C.font4)}>left</Text>
         <Text style={apply(C.textPrimary, C.font6)}>middle</Text>
         <Text style={apply(C.textSecondary, C.weightBold)}>right</Text>
+      </View>
+      <View>
+        <Text>Device width: {Dimensions.get('screen').width} px</Text>
+        <Text style={responsiveColor}>
+          If you are using a device with less than 301px as width, you should
+          see this in green.
+        </Text>
+        <Text style={responsiveColor}>
+          If you are using a device between 301px and 500px as width, you should
+          see this in blue.
+        </Text>
+        <Text style={responsiveColor}>
+          If you are using a device with more than 500px as width, you should
+          see this in red.
+        </Text>
       </View>
     </ScrollView>
   );

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -4,6 +4,7 @@ import C, {
   classNames,
   exists,
   extend,
+  responsive,
   Text,
   TextInput,
   TouchableOpacity,
@@ -165,6 +166,30 @@ test('classNames should return an array of styles by class names', () => {
   expect(classNames(C.bgRed, C.font4, C.p2)).toEqual([
     { backgroundColor: 'red', fontSize: 16, padding: 8 },
   ]);
+});
+
+test('responsive util', () => {
+  extend({
+    layout: {
+      sm: {
+        lte: 300,
+      },
+      md: {
+        gte: 301,
+        lte: 500,
+      },
+      l: {
+        gte: 501,
+      },
+    },
+  });
+
+  expect(
+    responsive({
+      sm: apply(C.bgBlue),
+      l: apply(C.bgRed),
+    })
+  ).toEqual([{ backgroundColor: 'red' }]);
 });
 
 test('compose classes', () => {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -16,6 +16,8 @@ export const components: DynamicObject<StyleProp<Styles | {}>> = {
   view: {},
 };
 
+const layout: DynamicObject<{ lte?: number; gte?: number }> = {};
+
 const colors: StringObject = {};
 
 const fonts: StringObject = {};
@@ -85,6 +87,7 @@ export default {
   colors,
   components,
   fonts,
+  layout,
   fontWeights,
   shadows,
   sizing,

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { StyleProp } from 'react-native';
+import { Dimensions, StyleProp } from 'react-native';
 import constants from './constants';
 import dictionary, { DictionaryKeys } from './dictionary';
 import { DynamicObject, Styles, StylesObject } from './types';
@@ -42,6 +42,26 @@ export const classNames = (
   });
 
   return apply(...classes.split(' '), styles);
+};
+
+export const responsive = (styles: DynamicObject<StyleProp<Styles>>) => {
+  const screenWidth = Dimensions.get('screen').width;
+
+  const currentSize = Object.entries(constants.layout).reduce(
+    (acc, [key, value]) => {
+      const lte = value.lte ?? screenWidth;
+      const gte = value.gte ?? 0;
+
+      if (screenWidth >= gte && screenWidth <= lte) {
+        return key;
+      }
+
+      return acc;
+    },
+    'default'
+  );
+
+  return apply(styles[currentSize] ?? styles.default ?? {});
 };
 
 type ConstantsKey = keyof typeof constants;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import constants, { boxShadow } from './constants';
 import { Text, TextInput, TouchableOpacity, View } from './components';
-import { apply, classNames, C, exists, extend } from './core';
+import { apply, classNames, C, exists, extend, responsive } from './core';
 import { getSizeFor } from './getters';
 
 export {
@@ -10,6 +10,7 @@ export {
   exists,
   extend,
   getSizeFor,
+  responsive,
   constants as theme,
   Text,
   TextInput,


### PR DESCRIPTION
Add a `responsive` method that allows the user to write in the same style block code different styles for the configured layouts.

![Example](https://media.giphy.com/media/KrM0cLn5lUk9ormpiU/giphy.gif)