### PR TITLE
fix: undefined values pass values as styles objects in classnames method

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -25,6 +25,10 @@ export const classNames = (
 
     if (typeof param === 'object') {
       Object.entries(param || {}).forEach(([key, value]) => {
+        if (typeof value === 'undefined') {
+          return;
+        }
+
         if (typeof value === 'boolean') {
           if (value) {
             classes += ` ${key.replace(/ +(?= )/g, '')}`;


### PR DESCRIPTION
In some scenarios, we notice a console warning for bad style objects like this
```
 Warning: Failed prop type: Invalid props.style key `familyRobotoMedium font8 line9 letterfour` supplied to `Text`.
Bad object: {
  "fontFamily": "Roboto-Bold",
  "lineHeight": 20,
  "letterSpacing": 0.2,
  "familyRobotoMedium font8 line9 letterfour": false,
  "familyRobotoMedium line8 lettertwo": false,
  "familyRobotoBold font6 line8 letterzero": false,
  "familyRobotoRegular font6 line8 letterzero": false,
  "familyRobotoBold font5 letterzero": false,
  "familyRobotoBold line5 lettertwo": true,
  "familyRobotoMedium line5 lettertwo": false,
  "familyRobotoRegular line5 letterzero": false,
  "familyRobotoRegular font3 letterzero": false,
  "alignLeft": false,
  "alignCenter": false,
  "alignRight": false,
  "color": "#4181f2"
}
```
Apparently, if a conditional value result is undefined instead of true or false, the style object is appended to `styles` object and generate this output to the component that call the `classnames` method